### PR TITLE
Add bash function for using drush from the host machine

### DIFF
--- a/local_docker_development/drupal_site_containers.md
+++ b/local_docker_development/drupal_site_containers.md
@@ -41,7 +41,7 @@ If you want to connect to a container wherever you are right now with your bash:
 
 ### Drush from your host machine
 
-To use drush, you can either connect to the container as above, or add a bash alias that will connect for you to run your drush command. To add the alias, add this to your .bashrc file:
+To use drush, you can either connect to the container as above, or add a bash function that will connect for you to run your drush command. To add the function, add this to your .bashrc file:
 
 ```
 ddrush() {

--- a/local_docker_development/drupal_site_containers.md
+++ b/local_docker_development/drupal_site_containers.md
@@ -21,7 +21,7 @@ During [Part I](./local_docker_development.md#part-i-shared-docker-containers) w
 
 ## Connect to the container
 
-To run commands like `drush`, `git` or other things within the container, you need to connect to the container.
+To run commands like `git` or other things within the container, you need to connect to the container.
 
 There are two ways for that:
 
@@ -39,6 +39,17 @@ If you want to connect to a container wherever you are right now with your bash:
 
 *Replace `changeme.com.docker.amazee.io` with the docker container you want to connect to*
 
+### Drush from your host machine
+
+To use drush, you can either connect to the container as above, or add a bash alias that will connect for you to run your drush command. To add the alias, add this to your .bashrc file:
+
+```
+ddrush() {
+ docker-compose exec --user drupal drupal bash -c "source ~/.bash_envvars && cd /var/www/drupal/public_html/web && drush $@"
+}
+```
+
+When you next start a bash session, you'll be able to use `ddrush` just like your normal `drush` command.
 
 ## SSH Agent
 

--- a/local_docker_development/drupal_site_containers.md
+++ b/local_docker_development/drupal_site_containers.md
@@ -45,7 +45,7 @@ To use drush, you can either connect to the container as above, or add a bash fu
 
 ```
 ddrush() {
- docker-compose exec --user drupal drupal bash -c "source ~/.bash_envvars && cd /var/www/drupal/public_html/web && drush $@"
+  docker-compose exec --user drupal drupal bash -c "source ~/.bash_envvars && cd /var/www/drupal/public_html/\"\$WEBROOT\" && drush $@"
 }
 ```
 


### PR DESCRIPTION
Aliases don't support arguments, so you have to do this in a trivial function. The bash -c has to load environment variables, because our settings.php wraps the database array in a check for one of the env vars. 

This is definitely short term - once we add an SSH service, it can go away.
