### PR TITLE
Correcting webroot path for drush from host.

### DIFF
--- a/local_docker_development/drupal_site_containers.md
+++ b/local_docker_development/drupal_site_containers.md
@@ -54,7 +54,7 @@ function ddrush() {
     args="${args} '$1'" && shift
   done;
 
-  docker-compose exec --user drupal drupal bash -c "source ~/.bash_envvars && cd /var/www/drupal/public_html/\"\$AMAZEEIO_WEBROOT\" && PATH=`pwd`/../vendor/bin:$PATH && drush ${args}"
+  docker-compose exec --user drupal drupal bash -c "source ~/.bash_envvars && cd $AMAZEEIO_WEBROOT && PATH=`pwd`/../vendor/bin:$PATH && drush ${args}"
 }
 ```
 
@@ -63,7 +63,7 @@ Fish Shell - ([fishshell.com](https://fishshell.com/)):
 function ddrush --description 'Drush fish (friendly interactive shell) function that detects Amazee.io Docker container. '
   if test -f (git rev-parse --show-toplevel)/.amazeeio.yml
     echo "Using Amazee.io Docker Container Drush"
-    command docker-compose exec --user drupal drupal bash -c "source ~/.bash_envvars && cd /var/www/drupal/public_html/docroot && PATH=`pwd`/../vendor/bin:\$PATH && drush $argv"
+    command docker-compose exec --user drupal drupal bash -c "source ~/.bash_envvars && cd $AMAZEEIO_WEBROOT && PATH=`pwd`/../vendor/bin:\$PATH && drush $argv"
   else
     command drush $argv
   end

--- a/local_docker_development/drupal_site_containers.md
+++ b/local_docker_development/drupal_site_containers.md
@@ -54,7 +54,7 @@ function ddrush() {
     args="${args} '$1'" && shift
   done;
 
-  docker-compose exec --user drupal drupal bash -c "source ~/.bash_envvars && cd $AMAZEEIO_WEBROOT && PATH=`pwd`/../vendor/bin:$PATH && drush ${args}"
+  docker-compose exec --user drupal drupal bash -c "source ~/.bash_envvars && cd \"$AMAZEEIO_WEBROOT\" && PATH=`pwd`/../vendor/bin:$PATH && drush ${args}"
 }
 ```
 
@@ -63,7 +63,7 @@ Fish Shell - ([fishshell.com](https://fishshell.com/)):
 function ddrush --description 'Drush fish (friendly interactive shell) function that detects Amazee.io Docker container. '
   if test -f (git rev-parse --show-toplevel)/.amazeeio.yml
     echo "Using Amazee.io Docker Container Drush"
-    command docker-compose exec --user drupal drupal bash -c "source ~/.bash_envvars && cd $AMAZEEIO_WEBROOT && PATH=`pwd`/../vendor/bin:\$PATH && drush $argv"
+    command docker-compose exec --user drupal drupal bash -c "source ~/.bash_envvars && cd \"$AMAZEEIO_WEBROOT\" && PATH=`pwd`/../vendor/bin:\$PATH && drush $argv"
   else
     command drush $argv
   end


### PR DESCRIPTION
Using the documented function for drush from your host machine results this error:

```
Douglass-MacBook-Pro:pmmi ddobrzynski$ ddrush

bash: line 0: cd: /var/www/drupal/public_html//var/www/drupal/public_html/html: No such file or directory
```

This is due to the fact that `$AMAZEEIO_WEBROOT` gets set to the full path in `~/.bash_envvars` in the container:

```
🐳 drupal@pmmi.org.docker.amazee.io:~/public_html/html (feature-amazeeio-conversion)$ cat ~/.bash_envvars
....
export AMAZEEIO_LOCATION="docker"
export AMAZEEIO_WEBROOT="/var/www/drupal/public_html/html"
...
export AMAZEEIO_TMP_PATH="/var/www/drupal/tmp"
export TMP="/var/www/drupal/tmp"
export TMPDIR="/var/www/drupal/tmp"
```
(Output condensed).

This means that it is only necessary to `cd $AMAZEEIO_WEBROOT` to change directory to the webroot. This PR fixes this for the Bash and Fish Shell functions for drush from your host machine.