### PR TITLE
Use $PATH from the container for ddrush bash function.

### DIFF
--- a/local_docker_development/drupal_site_containers.md
+++ b/local_docker_development/drupal_site_containers.md
@@ -54,7 +54,7 @@ function ddrush() {
     args="${args} '$1'" && shift
   done;
 
-  docker-compose exec --user drupal drupal bash -c "source ~/.bash_envvars && cd \"$AMAZEEIO_WEBROOT\" && PATH=`pwd`/../vendor/bin:$PATH && drush ${args}"
+  docker-compose exec --user drupal drupal bash -c "source ~/.bash_envvars && cd \"$AMAZEEIO_WEBROOT\" && PATH=`pwd`/../vendor/bin:\$PATH && drush ${args}"
 }
 ```
 


### PR DESCRIPTION
Bash command is entered in double quotes which means the `$PATH` is solved before command is executed in container. This leads to a situation in which the local user's `$PATH` is added before the container user's `$PATH` , and drush is executed with the wrong php version.